### PR TITLE
Use proper macro to determine MIPS ABI

### DIFF
--- a/gen/ioctl/main.c
+++ b/gen/ioctl/main.c
@@ -35,10 +35,10 @@ int main(void) {
     printf("#ifdef __powerpc__\n");
 #elif defined(__powerpc64__)
     printf("#ifdef __powerpc64__\n");
-#elif __mips == 32
-    printf("#if __mips == 32\n");
-#elif __mips == 64
-    printf("#if __mips == 64\n");
+#elif defined(__mips__) && _MIPS_SIM == _ABIO32
+    printf("#if defined(__mips__) && _MIPS_SIM == _ABIO32\n");
+#elif defined(__mips__) && _MIPS_SIM == _ABI64
+    printf("#if defined(__mips__) && _MIPS_SIM == _ABI64\n");
 #elif defined(__riscv) && __riscv_xlen == 64
     printf("#if defined(__riscv) && __riscv_xlen == 64\n");
 #elif defined(__s390x__)


### PR DESCRIPTION
`__mips` is used to determine current ISA reversion, at it may mismatch with actual ABI.

Use `__mips__` in conjunction with ` _MIPS_SIM` to determine actual ABI.

Reference: https://wiki.debian.org/ArchitectureSpecificsMemo